### PR TITLE
Bug/ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,16 +210,22 @@ and Other embedded objects.
 
 _Component replacements_ are of the form
 `{ $ref: "uri#/components/section/componentName" }` (`section` may be `schemas`,
-`parameters`, `response`, or any other `components`).
-Components replacements are only done for three-level JSON Pointers; for longer JSON pointers, see #4 below.
-For component replacements,
+`parameters`, `response`, or any other item in `components`).
+Component replacements are only done for three-level JSON Pointers; for longer JSON pointers, see #4 below.
+
+If the containing $ref object is at `/components/section/componentName0`, it does not contain any other keys, and
+`componentName0` equals `componentName`, the entire referenced object is inserted
+in place of the original `$ref` object and the mapping `uri#/components/section/componentName` &rArr; `#/components/section/componentName`
+is remembered.
+
+Otherwise,
 the content at the external URI is read (if not already cached) and the named component is
 inserted into the target document
-in side it's own components object, and the `$ref` replaced by
+inside it's own components object, and the `$ref` replaced by
 `{ $ref: "#/components/section/componentName" }`.
-The `ApiRefOptions.conflictPolicy` determines what to do if the component
-already exists and is a conflict (i.e. it was resolved from a different
-normalized path):
+
+The `ApiRefOptions.conflictPolicy` determines what to do if the `componentName`
+already exists in the target document:
 
 * it is either renamed with a unique numeric suffix (`rename`);
 * it is an error and the entire process fails (`error`)
@@ -228,7 +234,7 @@ normalized path):
 Note: The OpenAPI Specification requires that these paths be relative to the
 path in the
 `servers` object, but this tool simply uses relative references
-from the source URI.)
+from the source URI.
 
 ### Full resource replacements
 
@@ -237,6 +243,7 @@ _Full resource replacements_ are of the form
 is inserted, replacing the `$ref` object. The location is
 remembered so that any duplicate references to the normalized
 path are replaced with a local `{ $ref: #/location/of/resolved/resource }`.
+This is _only_ done if the `$ref` is the _only_ key in the object.
 
 ### Other embedded objects
 

--- a/src/ApiRefResolver.ts
+++ b/src/ApiRefResolver.ts
@@ -213,7 +213,7 @@ export class ApiRefResolver {
     })) as object;
   }
 
-  public static deepClone = (obj: any): any => {
+  public static deepClone = (obj) => {
     return v8.deserialize(v8.serialize(obj)); // kinda simple way to clone, but it works...
   };
 

--- a/src/JsonNavigation.ts
+++ b/src/JsonNavigation.ts
@@ -5,10 +5,9 @@
  */
 
 import { strict as assert } from 'assert';
-
 import * as jsonPointer from 'json-pointer';
-
 import type { Node } from './RefVisitor';
+import { ApiRefResolver } from './ApiRefResolver';
 
 /**
  * Represents a JSON object or JSON array
@@ -71,7 +70,10 @@ export class JsonNavigation {
       return undefined;
     }
     const noHash = fragment.substring(1);
-    return jsonPointer(this.document, noHash);
+    const val = jsonPointer(this.document, noHash);
+    // To be safe, we clone objects so we do not end up with YAML &ref_0/*ref_0
+    const clone = ApiRefResolver.deepClone(val);
+    return clone;
   }
 
   /**

--- a/test/data/api-d/api.yaml
+++ b/test/data/api-d/api.yaml
@@ -1,0 +1,47 @@
+openapi: 3.1.0
+info:
+  title: Multi-file OpenAPI
+  description: 'API definition that references components from ../api-a/api.yaml'
+  version: 0.1.0
+  contact: {}
+servers:
+  - url: /d
+tags:
+  - name: D
+    description: D
+
+paths:
+  /thing:
+    post:
+      operationId: createThing
+      summary: Create a Thing
+      description: Create a Thing
+      tags:
+        - B
+      security:
+        - apiKey: []
+      requestBody:
+        description: A new thing.
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK. A thing was returned.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/400CreateThing'
+        # '401':
+        #  $ref: '#/components/responses/401'
+components:
+  responses:
+    '400CreateThing':
+      description: Bad Request
+      $ref: '../api-a/api.yaml#/components/responses/400'
+    # '401':
+    #  description: Bad Request. (defined in api-d/api.yaml)
+    #  $ref: '../api-a/api.yaml#/components/responses/401'

--- a/test/data/root.yaml
+++ b/test/data/root.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Root API Elements
   description: 'Non-component API API elements'
@@ -9,10 +9,12 @@ servers:
 tags:
   - name: Health
     description: API Health
+
 paths:
   '/health':
     get:
       operationId: apiHealth
+      summary: API Health
       description: Return API Health
       tags:
         - Health
@@ -29,7 +31,7 @@ components:
       title: API Health
       description: >-
         API Health response as per
-        [IEFT RFC draft-inadarei-api-health-check-06](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check_)
+        [Health check](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check_)
         (truncated).
       type: object
       properties:

--- a/test/resolver.spec.ts
+++ b/test/resolver.spec.ts
@@ -161,6 +161,7 @@ describe('resolver test suite', () => {
     resolver
       .resolve()
       .then((result) => {
+        expect(yaml.dump(result.api).includes('ref_0')).toBeFalsy();
         const resolved = result.api as any;
         expect(resolved).toBeDefined();
         const components = resolved.components;
@@ -203,6 +204,35 @@ describe('resolver test suite', () => {
         const response422 = patch.responses[422];
         expect(response422.$ref).toBeDefined();
         expect(Object.keys(response422)).toEqual(['$ref']);
+        done();
+      })
+      .catch((ex) => {
+        done(ex);
+      });
+  });
+
+  test('resolves a ref of a ref', (done) => {
+    const sourceFileName = path.join(__dirname, 'data/api-d/api.yaml');
+    const resolver = new ApiRefResolver(sourceFileName);
+    resolver
+      .resolve()
+      .then((result) => {
+        const text = yaml.dump(result.api);
+        expect(text.includes('ref_0')).toBeFalsy();
+        const resolved = result.api as any;
+        expect(resolved).toBeDefined();
+        const components = resolved.components;
+        const responses = Object.keys(components.responses);
+        const expectedResponses = ['400', '400CreateThing'];
+        expect(responses).toEqual(expectedResponses);
+        const response = components.responses['400'];
+        expect(response).toBeDefined();
+        expect(response.$ref).toBeFalsy();
+        const post = resolved.paths['/thing'].post;
+        expect(post).toBeDefined();
+        const response400 = post.responses[400];
+        expect(response400.$ref).toBeDefined();
+        expect(Object.keys(response400)).toEqual(['$ref']);
         done();
       })
       .catch((ex) => {


### PR DESCRIPTION
Improve handling of component $ref and defer referencing items from inlined objects until after the code has been inlined and local `$ref` rewritten.
Add deepClone so that copies of items do not result in JSON/YAML `&ref_0`/`*ref_0` object references
